### PR TITLE
General layout revamp

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -8,6 +8,10 @@
   src: url("src/assets/Labrada-Italic-VariableFont_wght.ttf");
 }
 
+.hidden {
+  display: none;
+}
+
 body, html {
   background-color: transparent;
   display: flex;

--- a/src/App.css
+++ b/src/App.css
@@ -16,6 +16,9 @@ body, html {
   background-color: transparent;
   display: flex;
   flex-direction: column;
+  margin: 0;
+  padding: 0;
+  height: 100%;
 }
 
 p {
@@ -28,24 +31,8 @@ p {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  align-items: ;
-}
-
-.queue-container {
-  width: 15%;
-  border: 1px solid black;
 }
 
 .header-img {
   height: 40px;
 }
-
-.rune-container {
-  display: flex;
-  align-items: center;
-  justify-content: end;
-  margin: 0;
-  width: 100%;
-  height: 200px;
-}
-

--- a/src/App.css
+++ b/src/App.css
@@ -36,10 +36,6 @@ p {
   border: 1px solid black;
 }
 
-.top-right-container {
-  width: 400px;
-}
-
 .header-img {
   height: 40px;
 }
@@ -53,13 +49,3 @@ p {
   height: 200px;
 }
 
-.button-cont {
-  display: flex;
-  justify-content: center;
-}
-
-.button {
-  height: 50px;
-  width: 100px;
-  cursor: pointer;
-}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -59,6 +59,7 @@ function App() {
     "The Unknown"
   ])
   const [spokenWords] = useState([new Audio("src/assets/Tala.mp3"), new Audio("src/assets/Nogr.mp3")]);
+  const [isSpeakButtonHovered, setSpeakButtonHovered] = useState(false);
 
   function dropRune () {
     {spokenWords && spokenWords[0].play();}
@@ -83,20 +84,19 @@ function App() {
 
   return (
     <div className="app-container">
-      <div className="queue-container">
-        <Queue />
-      </div>
+      <Queue
+        isSpeakButtonHovered={isSpeakButtonHovered}/>
 
       <CenterPiece
         clearRunes={clearRunes}
         dropRune={dropRune}
-        currentRunes={currentRunes}/>
+        currentRunes={currentRunes}
+        isSpeakButtonHovered={isSpeakButtonHovered}
+        setSpeakButtonHovered={setSpeakButtonHovered}/>
 
       <CornerPiece
-        clearRunes={clearRunes}
-        dropRune={dropRune}
         currentRunes={currentRunes}/>
-      
+
     </div>
   )
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import './App.css'
 import RuneList from "./RuneList";
 import Queue from './Queue';
+import CenterPiece from './CenterPiece';
 
 function App() {
   const [currentRunes, setCurrentRunes] = useState([]);
@@ -84,6 +85,12 @@ function App() {
       <div className="queue-container">
         <Queue />
       </div>
+
+      <CenterPiece
+        clearRunes={clearRunes}
+        dropRune={dropRune}
+        currentRunes={currentRunes}/>
+
       <div className="top-right-container">
         <div className="header-container">
           <img

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import './App.css'
 import RuneList from "./RuneList";
 import Queue from './Queue';
 import CenterPiece from './CenterPiece';
+import CornerPiece from './CornerPiece';
 
 function App() {
   const [currentRunes, setCurrentRunes] = useState([]);
@@ -91,28 +92,11 @@ function App() {
         dropRune={dropRune}
         currentRunes={currentRunes}/>
 
-      <div className="top-right-container">
-        <div className="header-container">
-          <img
-            src={"src/assets/Words_of_destiny.svg"}
-            alt="Words of Destiny"
-            className="header-img"/>
-        </div>
-        <div className="rune-container">
-          <RuneList currentRunes = {currentRunes}/>
-        </div>
-        <div className="button-cont">
-          {currentRunes.length === 3 ?
-          <img
-            src={"src/assets/Enough.svg"}
-            className="button"
-            onClick={clearRunes} />:
-          <img
-            src={"src/assets/Speak.svg"}
-            className="button"
-            onClick={dropRune} />}
-        </div>
-      </div>
+      <CornerPiece
+        clearRunes={clearRunes}
+        dropRune={dropRune}
+        currentRunes={currentRunes}/>
+      
     </div>
   )
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 import { useState } from 'react';
 import './App.css'
-import RuneList from "./RuneList";
 import Queue from './Queue';
 import CenterPiece from './CenterPiece';
 import CornerPiece from './CornerPiece';
@@ -60,6 +59,7 @@ function App() {
   ])
   const [spokenWords] = useState([new Audio("src/assets/Tala.mp3"), new Audio("src/assets/Nogr.mp3")]);
   const [isSpeakButtonHovered, setSpeakButtonHovered] = useState(false);
+  const [isSpeakButtonClicked, setSpeakButtonClicked] = useState(false);
 
   function dropRune () {
     {spokenWords && spokenWords[0].play();}
@@ -85,14 +85,16 @@ function App() {
   return (
     <div className="app-container">
       <Queue
-        isSpeakButtonHovered={isSpeakButtonHovered}/>
+        isSpeakButtonHovered={isSpeakButtonHovered}
+        isSpeakButtonClicked={isSpeakButtonClicked}/>
 
       <CenterPiece
         clearRunes={clearRunes}
         dropRune={dropRune}
         currentRunes={currentRunes}
         isSpeakButtonHovered={isSpeakButtonHovered}
-        setSpeakButtonHovered={setSpeakButtonHovered}/>
+        setSpeakButtonHovered={setSpeakButtonHovered}
+        setSpeakButtonClicked={setSpeakButtonClicked}/>
 
       <CornerPiece
         currentRunes={currentRunes}/>

--- a/src/CenterPiece.css
+++ b/src/CenterPiece.css
@@ -1,0 +1,6 @@
+.center-piece-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+}

--- a/src/CenterPiece.css
+++ b/src/CenterPiece.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  height: 100vh;
 }
 
 .button-cont {
@@ -14,4 +15,13 @@
   height: 50px;
   width: 100px;
   cursor: pointer;
+}
+
+.rune-container {
+  display: flex;
+  align-items: center;
+  justify-content: end;
+  margin: 0;
+  width: 100%;
+  height: 200px;
 }

--- a/src/CenterPiece.css
+++ b/src/CenterPiece.css
@@ -4,3 +4,14 @@
   align-items: center;
   justify-content: center;
 }
+
+.button-cont {
+  display: flex;
+  justify-content: center;
+}
+
+.button {
+  height: 50px;
+  width: 100px;
+  cursor: pointer;
+}

--- a/src/CenterPiece.jsx
+++ b/src/CenterPiece.jsx
@@ -2,7 +2,7 @@ import RuneList from "./RuneList";
 import PropTypes from "prop-types";
 import './CenterPiece.css';
 
-function CenterPiece({ clearRunes, dropRune, currentRunes }) {
+function CenterPiece({ clearRunes, dropRune, currentRunes, isSpeakButtonHovered, setSpeakButtonHovered }) {
 
 
   return (
@@ -21,11 +21,14 @@ function CenterPiece({ clearRunes, dropRune, currentRunes }) {
         <img
           src={"src/assets/Enough.svg"}
           className="button"
-          onClick={clearRunes} />:
+          onClick={clearRunes}/>
+          :
         <img
           src={"src/assets/Speak.svg"}
           className="button"
-          onClick={dropRune} />}
+          onClick={dropRune}
+          onMouseEnter={()=>setSpeakButtonHovered(!isSpeakButtonHovered)}
+          onMouseOut={()=>setSpeakButtonHovered(!isSpeakButtonHovered)}/>}
       </div>
     </div>
   )
@@ -36,5 +39,7 @@ export default CenterPiece;
 CenterPiece.propTypes = {
   clearRunes: PropTypes.func,
   dropRune: PropTypes.func,
-  currentRunes: PropTypes.object
+  currentRunes: PropTypes.object,
+  setSpeakButtonHovered: PropTypes.func,
+  isSpeakButtonHovered: PropTypes.bool
 }

--- a/src/CenterPiece.jsx
+++ b/src/CenterPiece.jsx
@@ -1,0 +1,40 @@
+import RuneList from "./RuneList";
+import PropTypes from "prop-types";
+import './CenterPiece.css';
+
+function CenterPiece({ clearRunes, dropRune, currentRunes }) {
+
+
+  return (
+    <div className="center-piece-container">
+      <div className="header-container">
+        <img
+          src={"src/assets/Words_of_destiny.svg"}
+          alt="Words of Destiny"
+          className="header-img"/>
+      </div>
+      <div className="rune-container">
+        <RuneList currentRunes = {currentRunes}/>
+      </div>
+      <div className="button-cont">
+        {currentRunes.length === 3 ?
+        <img
+          src={"src/assets/Enough.svg"}
+          className="button"
+          onClick={clearRunes} />:
+        <img
+          src={"src/assets/Speak.svg"}
+          className="button"
+          onClick={dropRune} />}
+      </div>
+    </div>
+  )
+}
+
+export default CenterPiece;
+
+CenterPiece.propTypes = {
+  clearRunes: PropTypes.func,
+  dropRune: PropTypes.func,
+  currentRunes: PropTypes.object
+}

--- a/src/CenterPiece.jsx
+++ b/src/CenterPiece.jsx
@@ -2,8 +2,21 @@ import RuneList from "./RuneList";
 import PropTypes from "prop-types";
 import './CenterPiece.css';
 
-function CenterPiece({ clearRunes, dropRune, currentRunes, isSpeakButtonHovered, setSpeakButtonHovered }) {
+function CenterPiece({
+  clearRunes,
+  dropRune,
+  currentRunes,
+  isSpeakButtonHovered,
+  setSpeakButtonHovered,
+  setSpeakButtonClicked }) {
 
+  function clickDropRune () {
+    dropRune();
+    setSpeakButtonClicked(true);
+    setTimeout(() => {
+      setSpeakButtonClicked(false);
+    }, 500);
+  }
 
   return (
     <div className="center-piece-container">
@@ -26,7 +39,7 @@ function CenterPiece({ clearRunes, dropRune, currentRunes, isSpeakButtonHovered,
         <img
           src={"src/assets/Speak.svg"}
           className="button"
-          onClick={dropRune}
+          onClick={clickDropRune}
           onMouseEnter={()=>setSpeakButtonHovered(!isSpeakButtonHovered)}
           onMouseOut={()=>setSpeakButtonHovered(!isSpeakButtonHovered)}/>}
       </div>
@@ -41,5 +54,6 @@ CenterPiece.propTypes = {
   dropRune: PropTypes.func,
   currentRunes: PropTypes.object,
   setSpeakButtonHovered: PropTypes.func,
-  isSpeakButtonHovered: PropTypes.bool
+  isSpeakButtonHovered: PropTypes.bool,
+  setSpeakButtonClicked: PropTypes.func
 }

--- a/src/CornerPiece.css
+++ b/src/CornerPiece.css
@@ -1,0 +1,4 @@
+.corner-piece-container {
+  width: 400px;
+}
+

--- a/src/CornerPiece.jsx
+++ b/src/CornerPiece.jsx
@@ -1,0 +1,27 @@
+import RuneList from "./RuneList";
+import PropTypes from "prop-types";
+import './CornerPiece.css'
+
+function CornerPiece ({ currentRunes }) {
+  return (
+    <div className="corner-piece-container">
+      <div className="header-container">
+        <img
+          src={"src/assets/Words_of_destiny.svg"}
+          alt="Words of Destiny"
+          className="header-img"/>
+      </div>
+      <div className="rune-container">
+        <RuneList currentRunes = {currentRunes}/>
+      </div>
+    </div>
+  )
+}
+
+export default CornerPiece;
+
+CornerPiece.propTypes = {
+  clearRunes: PropTypes.func,
+  dropRune: PropTypes.func,
+  currentRunes: PropTypes.object
+}

--- a/src/Queue.css
+++ b/src/Queue.css
@@ -1,0 +1,4 @@
+.queue-container {
+  width: 15%;
+  border: 1px solid black;
+}

--- a/src/Queue.jsx
+++ b/src/Queue.jsx
@@ -107,7 +107,7 @@ function Queue() {
       "data": {
         "username": "Emma O'Connell PhD",
         "amount": 8,
-        "message": "",
+        "message": "Non mais mec j sais pas si tu te rends compte à quel point c'est ouf ce que tu fais, mois je pourrais jamais le faire, je sais parce que j ai déjà essayé hahaha. En tout cas bravo et continue comme ca, ca fait trop plaisir de voir des gens faire des trucs si cools.",
         "tier": "prime",
         "avatar": "https://cdn.streamelements.com/static/default-avatar.png"
       },

--- a/src/Queue.jsx
+++ b/src/Queue.jsx
@@ -426,8 +426,9 @@ function Queue({ isSpeakButtonHovered, isSpeakButtonClicked }) {
             amount = {sift[1]}
             message = {sift[2]}
             type = {sift[3]}
+            isSpeakButtonClicked={isSpeakButtonClicked}
             {...(index === 0 && {isSpeakButtonHovered})}
-            {...(index === 0 && {isSpeakButtonClicked})}/>
+            firstElement = {index === 0 ? true : false}/>
         </div>
       ))}
     </div>

--- a/src/Queue.jsx
+++ b/src/Queue.jsx
@@ -1,7 +1,9 @@
 import { useEffect, useState } from 'react';
 import QueueElement from './QueueElement';
+import "./Queue.css";
+import PropTypes from "prop-types";
 
-function Queue() {
+function Queue({ isSpeakButtonHovered }) {
   const jwtToken = import.meta.env.VITE_JWT;
   const channelId = import.meta.env.VITE_CHANNEL_ID;
   const responseExample = [
@@ -403,18 +405,17 @@ function Queue() {
     siftThroughResponse(responseExample);
   }, []);
 
-  // console.log(sifted);
-  console.log(sifted)
-
   return (
-    <div className="queue">
+    <div className="queue-container">
       {sifted && sifted.map((sift, index) => (
         <div key={index}>
           <QueueElement
             username = {sift[0]}
             amount = {sift[1]}
             message = {sift[2]}
-            type = {sift[3]}/>
+            type = {sift[3]}
+            // isSpeakButtonHovered={index === 0 ? isSpeakButtonHovered : undefined}
+            {...(index === 0 && {isSpeakButtonHovered})}/>
         </div>
       ))}
     </div>
@@ -422,3 +423,7 @@ function Queue() {
 }
 
 export default Queue;
+
+Queue.propTypes = {
+  isSpeakButtonHovered: PropTypes.bool
+}

--- a/src/Queue.jsx
+++ b/src/Queue.jsx
@@ -3,7 +3,7 @@ import QueueElement from './QueueElement';
 import "./Queue.css";
 import PropTypes from "prop-types";
 
-function Queue({ isSpeakButtonHovered }) {
+function Queue({ isSpeakButtonHovered, isSpeakButtonClicked }) {
   const jwtToken = import.meta.env.VITE_JWT;
   const channelId = import.meta.env.VITE_CHANNEL_ID;
   const responseExample = [
@@ -401,6 +401,18 @@ function Queue({ isSpeakButtonHovered }) {
     console.log(sifted);
   }
 
+  function removeFirstQueueElement () {
+    setTimeout(() => {
+      setSifted(sifted.slice(1, sifted.length))
+    }, 500);
+  }
+
+  useEffect(() => {
+    if (isSpeakButtonClicked) {
+      removeFirstQueueElement();
+    }
+  }, [isSpeakButtonClicked]);
+
   useEffect(() => {
     siftThroughResponse(responseExample);
   }, []);
@@ -414,8 +426,8 @@ function Queue({ isSpeakButtonHovered }) {
             amount = {sift[1]}
             message = {sift[2]}
             type = {sift[3]}
-            // isSpeakButtonHovered={index === 0 ? isSpeakButtonHovered : undefined}
-            {...(index === 0 && {isSpeakButtonHovered})}/>
+            {...(index === 0 && {isSpeakButtonHovered})}
+            {...(index === 0 && {isSpeakButtonClicked})}/>
         </div>
       ))}
     </div>
@@ -425,5 +437,6 @@ function Queue({ isSpeakButtonHovered }) {
 export default Queue;
 
 Queue.propTypes = {
-  isSpeakButtonHovered: PropTypes.bool
+  isSpeakButtonHovered: PropTypes.bool,
+  isSpeakButtonClicked: PropTypes.bool
 }

--- a/src/QueueElement.css
+++ b/src/QueueElement.css
@@ -1,5 +1,6 @@
 .qe-container {
   padding: 0.5rem;
+  border-bottom: 1px solid black;
 }
 
 .qe-container h5 {
@@ -41,6 +42,27 @@
   justify-content: center;
 }
 
+.qe-message-long {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: relative;
+}
+
 .qe-message {
   font-family: "Labrada", sans-serif;
+  text-align: justify;
+}
+
+.qe-full-message-long {
+  font-family: "Labrada", sans-serif;
+  text-align: justify;
+  border: 1px solid black;
+  border-radius: 15px;
+  position: absolute;
+  width: 100%;
+  top: -30px;
+  right: -325px;
+  padding: 1rem;
 }

--- a/src/QueueElement.css
+++ b/src/QueueElement.css
@@ -9,6 +9,10 @@
   background-color: grey;
 }
 
+.end {
+  transform: translateX(400px);
+}
+
 .qe-container h5 {
   margin-top: 0;
   margin-bottom:0;

--- a/src/QueueElement.css
+++ b/src/QueueElement.css
@@ -1,9 +1,20 @@
 .qe-container {
   padding: 0.5rem;
   border-bottom: 1px solid black;
+  background-color: transparent;
+  transition: 0.2s;
+}
+
+.grey {
+  background-color: grey;
 }
 
 .qe-container h5 {
+  margin-top: 0;
+  margin-bottom:0;
+}
+
+.qe-container.grey h5 {
   margin-top: 0;
   margin-bottom:0;
 }

--- a/src/QueueElement.css
+++ b/src/QueueElement.css
@@ -2,7 +2,8 @@
   padding: 0.5rem;
   border-bottom: 1px solid black;
   background-color: transparent;
-  transition: 0.2s;
+  transition: 0.5s;
+  opacity: 1;
 }
 
 .grey {
@@ -11,6 +12,11 @@
 
 .end {
   transform: translateX(400px);
+  opacity: 0;
+}
+
+.top {
+  transform: translateY(200px);
 }
 
 .qe-container h5 {

--- a/src/QueueElement.jsx
+++ b/src/QueueElement.jsx
@@ -2,7 +2,14 @@ import { useState, useEffect } from "react";
 import PropTypes from 'prop-types';
 import "./QueueElement.css"
 
-function QueueElement({ username, amount, message, type, isSpeakButtonHovered }) {
+function QueueElement({
+  username,
+  amount,
+  message,
+  type,
+  isSpeakButtonHovered,
+  isSpeakButtonClicked }) {
+
   const [messageLong, setMessageToLong] = useState(false);
   const [isHovered, setHovered] = useState(false);
 
@@ -28,7 +35,8 @@ function QueueElement({ username, amount, message, type, isSpeakButtonHovered })
   }
 
   return (
-    <div className={isSpeakButtonHovered ? "qe-container grey" : "qe-container"}>
+    <div className={isSpeakButtonHovered ? (isSpeakButtonClicked ? "qe-container end" : "qe-container grey") :"qe-container" }>
+    {/* // <div className={isSpeakButtonClicked ? "qe-container end" : "qe-container"}> */}
       <div className="qe-header">
         <h5 className="qe-username">{username}</h5>
         <h5 className="qe-type">{refineType(type)}</h5>
@@ -51,6 +59,7 @@ function QueueElement({ username, amount, message, type, isSpeakButtonHovered })
           <h5 className="qe-message">{message}</h5>
         }
       </div>
+    {/* // </div> */}
     </div>
   );
 }
@@ -62,5 +71,6 @@ QueueElement.propTypes = {
   amount: PropTypes.number,
   message: PropTypes.string,
   type: PropTypes.string,
-  isSpeakButtonHovered: PropTypes.bool
+  isSpeakButtonHovered: PropTypes.bool,
+  isSpeakButtonClicked: PropTypes.bool
 }

--- a/src/QueueElement.jsx
+++ b/src/QueueElement.jsx
@@ -8,7 +8,8 @@ function QueueElement({
   message,
   type,
   isSpeakButtonHovered,
-  isSpeakButtonClicked }) {
+  isSpeakButtonClicked,
+  firstElement }) {
 
   const [messageLong, setMessageToLong] = useState(false);
   const [isHovered, setHovered] = useState(false);
@@ -35,8 +36,11 @@ function QueueElement({
   }
 
   return (
-    <div className={isSpeakButtonHovered ? (isSpeakButtonClicked ? "qe-container end" : "qe-container grey") :"qe-container" }>
-    {/* // <div className={isSpeakButtonClicked ? "qe-container end" : "qe-container"}> */}
+    <div className={
+      isSpeakButtonHovered ?
+        (isSpeakButtonClicked ?
+          ( firstElement ? "qe-container end" : "qe-container top")
+            : "qe-container grey" ): "qe-container" }>
       <div className="qe-header">
         <h5 className="qe-username">{username}</h5>
         <h5 className="qe-type">{refineType(type)}</h5>
@@ -59,7 +63,6 @@ function QueueElement({
           <h5 className="qe-message">{message}</h5>
         }
       </div>
-    {/* // </div> */}
     </div>
   );
 }
@@ -72,5 +75,6 @@ QueueElement.propTypes = {
   message: PropTypes.string,
   type: PropTypes.string,
   isSpeakButtonHovered: PropTypes.bool,
-  isSpeakButtonClicked: PropTypes.bool
+  isSpeakButtonClicked: PropTypes.bool,
+  firstElement: PropTypes.bool
 }

--- a/src/QueueElement.jsx
+++ b/src/QueueElement.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import PropTypes from 'prop-types';
 import "./QueueElement.css"
 
-function QueueElement({ username, amount, message, type }) {
+function QueueElement({ username, amount, message, type, isSpeakButtonHovered }) {
   const [messageLong, setMessageToLong] = useState(false);
   const [isHovered, setHovered] = useState(false);
 
@@ -23,12 +23,12 @@ function QueueElement({ username, amount, message, type }) {
   function cutText(message) {
     const cut_message = [];
     cut_message.push(message.slice(0, 154) + "...");
-    cut_message.push('...'+message.slice(155, message.length-1))
+    cut_message.push('...'+ message.slice(155, message.length-1))
     return cut_message;
   }
 
   return (
-    <div className="qe-container">
+    <div className={isSpeakButtonHovered ? "qe-container grey" : "qe-container"}>
       <div className="qe-header">
         <h5 className="qe-username">{username}</h5>
         <h5 className="qe-type">{refineType(type)}</h5>
@@ -61,5 +61,6 @@ QueueElement.propTypes = {
   username: PropTypes.string,
   amount: PropTypes.number,
   message: PropTypes.string,
-  type: PropTypes.string
+  type: PropTypes.string,
+  isSpeakButtonHovered: PropTypes.bool
 }

--- a/src/QueueElement.jsx
+++ b/src/QueueElement.jsx
@@ -21,11 +21,10 @@ function QueueElement({ username, amount, message, type }) {
   }
 
   function cutText(message) {
-    if (message.length > 154) {
-      const cut_message = message.slice(0, 154) + "...";
-      return cut_message;
-    }
-    return message;
+    const cut_message = [];
+    cut_message.push(message.slice(0, 154) + "...");
+    cut_message.push('...'+message.slice(155, message.length-1))
+    return cut_message;
   }
 
   return (
@@ -43,10 +42,10 @@ function QueueElement({ username, amount, message, type }) {
             <h5
               className="qe-message"
               onMouseEnter={() => setHovered(true)}
-              onMouseOut={() => setHovered(false)}>{cutText(message)}</h5>
+              onMouseOut={() => setHovered(false)}>{cutText(message)[0]}</h5>
             <h5 className={isHovered ?
               "qe-full-message-long" :
-              "qe-full-message-long hidden"}>{message}</h5>
+              "qe-full-message-long hidden"}>{cutText(message)[1]}</h5>
           </div>
           :
           <h5 className="qe-message">{message}</h5>

--- a/src/QueueElement.jsx
+++ b/src/QueueElement.jsx
@@ -1,11 +1,10 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect } from "react";
 import PropTypes from 'prop-types';
 import "./QueueElement.css"
 
 function QueueElement({ username, amount, message, type }) {
   const [messageLong, setMessageToLong] = useState(false);
   const [isHovered, setHovered] = useState(false);
-  const uncutTextRef = useRef(null);
 
   useEffect(() => {
     if (message.length > 150) {
@@ -28,10 +27,6 @@ function QueueElement({ username, amount, message, type }) {
     }
     return message;
   }
-
-  // function displayUncutText() {
-  //   uncutTextRef.current.classList.remove('hidden');
-  // }
 
   return (
     <div className="qe-container">

--- a/src/QueueElement.jsx
+++ b/src/QueueElement.jsx
@@ -1,7 +1,18 @@
+import { useState, useEffect, useRef } from "react";
 import PropTypes from 'prop-types';
 import "./QueueElement.css"
 
 function QueueElement({ username, amount, message, type }) {
+  const [messageLong, setMessageToLong] = useState(false);
+  const [isHovered, setHovered] = useState(false);
+  const uncutTextRef = useRef(null);
+
+  useEffect(() => {
+    if (message.length > 150) {
+      setMessageToLong(true);
+    }
+  }, [message]);
+
   function refineType(type) {
     if (type === "subscriber") {
       return 'Sub'
@@ -9,6 +20,18 @@ function QueueElement({ username, amount, message, type }) {
       return 'Tip'
     }
   }
+
+  function cutText(message) {
+    if (message.length > 154) {
+      const cut_message = message.slice(0, 154) + "...";
+      return cut_message;
+    }
+    return message;
+  }
+
+  // function displayUncutText() {
+  //   uncutTextRef.current.classList.remove('hidden');
+  // }
 
   return (
     <div className="qe-container">
@@ -20,7 +43,19 @@ function QueueElement({ username, amount, message, type }) {
         <h5 className="qe-amount">${amount}</h5>
       </div>
       <div className="qe-footer">
-        <h5 className="qe-message">{message}</h5>
+        {messageLong ?
+          <div className="qe-message-long">
+            <h5
+              className="qe-message"
+              onMouseEnter={() => setHovered(true)}
+              onMouseOut={() => setHovered(false)}>{cutText(message)}</h5>
+            <h5 className={isHovered ?
+              "qe-full-message-long" :
+              "qe-full-message-long hidden"}>{message}</h5>
+          </div>
+          :
+          <h5 className="qe-message">{message}</h5>
+        }
       </div>
     </div>
   );


### PR DESCRIPTION
- A message that is too long is now cut to a maximum of 150 characters to not unbalance the queue layout. 
- Hovering over the message displays the whole text on the right side.
- Created the CenterPiece component to put the draw of runes front and center.
- Changed the cutText function of the QueueElement component to only additionally display the missing part of the message and not the whole thing.
- Refactored App component to create a CornerPiece that will be a minimized version of CenterPiece.
- Added an highlight on the first element of the queue when hovering over the Speak button to highlight which rune is gonna get drawn (the first one).
- Linked the Speak button with the Queue. Clicking it deletes the first item. 
- Additional animation added.
- Adjusted the animation to make the first QueueElement disappear on click of the Speak button.